### PR TITLE
Add style, use foreground & background colors

### DIFF
--- a/src/containerStyles.js
+++ b/src/containerStyles.js
@@ -1,0 +1,53 @@
+exports.wrapperStyles = (props) => {
+  return {
+    background: props.backgroundColor,
+    borderRadius: '10px',
+    border: `1px solid ${props.foregroundColor}`,
+    height: '30px',
+    opacity: 0.6,
+    padding: "5px 0 5px 10px",
+    position: 'absolute',
+    right: '10px',
+    top: '5px',
+    width: '215px',
+    zIndex: '9999',
+  };
+};
+
+exports.inputStyles = (props) => {
+  return {
+    background: "none",
+    border: "none",
+    color: props.foregroundColor,
+    fontSize: '0.8em',
+    opacity: 1,
+    outline: "none",
+  };
+};
+
+const buttonStyles = (props) => {
+  return {
+    background: props.foregroundColor,
+    border: 'none',
+    color: props.backgroundColor,
+    height: '100%',
+    paddingBottom: '2px',
+    opacity: 0.6,
+    outline: 'none',
+    position: 'relative',
+    top: '-2px',
+    width: '12%',
+  }
+}
+
+exports.previousButtonStyles = (props) => {
+  return Object.assign({}, buttonStyles(props), {
+    borderRadius: '10px 0 0 10px',
+  });
+};
+
+exports.nextButtonStyles = (props) => {
+  return Object.assign({}, buttonStyles(props), {
+    borderRadius: '0 10px 10px 0',
+  });
+};

--- a/src/containers.js
+++ b/src/containers.js
@@ -1,5 +1,7 @@
 const { resetCurrentMatch, setCurrentMatch, toggleSearchInput,
         updateSearchText } = require('./actions');
+const { wrapperStyles, inputStyles, previousButtonStyles,
+  nextButtonStyles } = require('./containerStyles');
 const { DIRECTION_NEXT, DIRECTION_PREV, ENTER, ESCAPE } = require('./constants');
 
 exports.mapTermsState = (state, map) => (
@@ -176,7 +178,7 @@ exports.decorateTerm = (Term, { React }) => {
       term.selectionManager._model.selectionStart = [_startIdx, _startRow];
       term.selectionManager._model.selectionEnd = [_endIdx + 1, _endRow];
       term.selectionManager.refresh();
-      term.scrollDisp(_startRow - term.buffer.ydisp);
+      term.scrollLines(_startRow - term.buffer.ydisp);
       window.store.dispatch(
         setCurrentMatch(uid, _startRow, _startIdx, _endIdx, _endRow)
       );
@@ -420,14 +422,7 @@ exports.decorateTerm = (Term, { React }) => {
         this.toggleInput() &&
         React.createElement('div', {
           className: 'hyper-search-wrapper',
-          style: {
-            height: '30px',
-            position: 'absolute',
-            right: '10px',
-            top: '5px',
-            width: '200px',
-            zIndex: '9999'
-          },
+          style: wrapperStyles(this.props),
         },
         React.createElement('input', {
           id: 'hyper-search-input',
@@ -437,18 +432,18 @@ exports.decorateTerm = (Term, { React }) => {
           onKeyDown: this.handleOnKeyDown,
           placeholder: 'Search...',
           ref: (node) => { this.inputNode = node; },
-          style: { fontSize: '0.8em', height: '100%' },
+          style: inputStyles(this.props),
           value: this.getInputText(),
         }),
         React.createElement(
-          'button', {
-            style: { height: '100%', width: '12%' },
+          'button', { 
+            style: previousButtonStyles(this.props),
             onClick: this.handleSearchPrev,
           },
           '◀️'),
         React.createElement(
-          'button', {
-            style: { height: '100%', width: '12%' },
+          'button', { 
+            style: nextButtonStyles(this.props),
             onClick: this.handleSearchNext,
           },
           '▶️'


### PR DESCRIPTION
addresses https://github.com/jaanauati/hyper-search/issues/15
- break out styles into their own file
- add extra style to enhance the look of search
- support user background/foreground colors
- change `term.scrollDisp` to `term.scrollLines`

With #000 background, #fff foreground
  
<img width="250" alt="screen shot 2018-03-01 at 2 22 08 pm" src="https://user-images.githubusercontent.com/1680215/36867909-48714976-1d5c-11e8-8fab-42b630243b71.png">

With #fff background, #000 foreground
<img width="231" alt="screen shot 2018-03-01 at 2 22 45 pm" src="https://user-images.githubusercontent.com/1680215/36867931-6224005c-1d5c-11e8-89b7-a16dc26c28c4.png">

