### PR TITLE
fix infinite loop when line is empty

### DIFF
--- a/src/containers.js
+++ b/src/containers.js
@@ -283,7 +283,7 @@ exports.decorateTerm = (Term, { React }) => {
       while (true) {
         let inputIdx = initialInputIdx;
         let lineIdx = _startIdx;
-        while (lineIdx !== currentLineLastIdx) {
+        while (lineIdx !== currentLineLastIdx && currentLineLastIdx !== 0) {
           if (inputIdx === initialInputIdx) {
             _startRow = rowNr;
             _startIdx = lineIdx;


### PR DESCRIPTION
This bug freezes the entire Hyper UI. When the searched line is empty, an infinite loop happens. 
TBH the whole search function needs a bit of refactoring, it has some duplicate code and could be split to more functions.